### PR TITLE
Change path on file load

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(traffic-editor
   gui/model.cpp
   gui/param.cpp
   gui/polygon.cpp
+  gui/preferences_dialog.cpp
   gui/vertex.cpp
 )
 

--- a/gui/editor.cpp
+++ b/gui/editor.cpp
@@ -30,6 +30,7 @@
 
 #include "editor.h"
 #include "level_dialog.h"
+#include "preferences_dialog.h"
 #include "map_view.h"
 
 
@@ -118,6 +119,10 @@ Editor::Editor(QWidget *parent)
 
   QAction *exit_action = file_menu->addAction("E&xit", this, &QWidget::close);
   exit_action->setShortcut(tr("Ctrl+Q"));
+
+  // EDIT MENU
+  QMenu *edit_menu = menuBar()->addMenu("&Edit");
+  edit_menu->addAction("&Preferences...", this, &Editor::edit_preferences);
 
   // LEVEL MENU
   QMenu *level_menu = menuBar()->addMenu("&Level");
@@ -248,6 +253,7 @@ void Editor::populate_model_name_list_widget()
 
   const double model_meters_per_pixel = y["meters_per_pixel"].as<double>();
   const YAML::Node ym = y["models"];
+  model_name_list_widget->clear();
   for (YAML::const_iterator it = ym.begin(); it != ym.end(); ++it) {
     std::string model_name = it->as<std::string>();
     model_name_list_widget->addItem(model_name.c_str());
@@ -420,6 +426,14 @@ void Editor::level_edit()
         this,
         "work in progress", "TODO: use this data...sorry.");
   }
+}
+
+void Editor::edit_preferences()
+{
+  PreferencesDialog preferences_dialog(this);
+
+  if (preferences_dialog.exec() == QDialog::Accepted)
+    populate_model_name_list_widget();
 }
 
 void Editor::level_add()

--- a/gui/editor.cpp
+++ b/gui/editor.cpp
@@ -49,6 +49,9 @@ Editor::Editor(QWidget *parent)
 {
   instance = this;
 
+  QSettings settings;
+  qDebug("settings filename: [%s]", qUtf8Printable(settings.fileName()));
+
   scene = new QGraphicsScene(this);
 
   map_view = new MapView(this);
@@ -214,8 +217,26 @@ Editor::Editor(QWidget *parent)
 void Editor::populate_model_name_list_widget()
 {
   // This function may throw exceptions. Caller should be ready for them!
+
+  QSettings settings;
+  const QString THUMBNAIL_PATH_KEY("editor/thumbnail_path");
+  QString thumbnail_path(settings.value(THUMBNAIL_PATH_KEY).toString());
+  if (thumbnail_path.isEmpty())
+  {
+    // Currently not sure how to do this the "right" way. For now assume
+    // everybody is building from source, I guess (?).
+    // todo: figure out something better in the future for binary installs
+    thumbnail_path =
+        QDir::cleanPath(
+            QDir(QApplication::applicationDirPath()).filePath("../thumbnails")
+        );
+    settings.setValue(THUMBNAIL_PATH_KEY, thumbnail_path);
+  }
+
+  QString model_list_path = QDir(thumbnail_path).filePath("model_list.yaml");
+
   YAML::Node y;
-  std::string filename("thumbnails/model_list.yaml");
+  std::string filename(model_list_path.toStdString());
   try {
     y = YAML::LoadFile(filename);
   }
@@ -279,6 +300,12 @@ bool Editor::load_project(const QString &filename)
   map_view->zoom_fit(map, level_idx);
 
   return true;
+}
+
+bool Editor::load_previous_project()
+{
+  // todo...
+  return false;
 }
 
 void Editor::update_level_buttons()

--- a/gui/editor.h
+++ b/gui/editor.h
@@ -96,6 +96,8 @@ private slots:
   void about();
 
 private:
+  void edit_preferences();
+
   void level_add();
   void level_edit();
   void update_level_buttons();

--- a/gui/editor.h
+++ b/gui/editor.h
@@ -28,6 +28,7 @@
 #include <QGraphicsPolygonItem>
 #include <QGraphicsScene>
 #include <QMainWindow>
+#include <QSettings>
 
 
 class MapView;
@@ -59,7 +60,13 @@ public:
   Editor(QWidget *parent = nullptr);
   static Editor *get_instance();
 
+  /// Load a project, replacing the current Map with a Map inflated from
+  /// the YAML filename provided to this function.
   bool load_project(const QString &filename);
+
+  /// Attempt to load the most recently saved project, just for convenience
+  /// when starting the application since often we want to 'resume' editing.
+  bool load_previous_project();
 
   enum {
     SELECT = 1,

--- a/gui/editor_model.cpp
+++ b/gui/editor_model.cpp
@@ -17,8 +17,10 @@
 
 #include <algorithm>
 
+#include <QDir>
 #include <QImage>
 #include <QImageReader>
+#include <QSettings>
 
 #include "editor_model.h"
 
@@ -48,8 +50,16 @@ QPixmap EditorModel::get_pixmap()
     return pixmap;
 
   // if we get here, we have to load the image from disk and generate pixmap
+
+  const QString THUMBNAIL_PATH_KEY("editor/thumbnail_path");
+  QSettings settings;
+  QString thumbnail_path(settings.value(THUMBNAIL_PATH_KEY).toString());
+
   string filename =
-      string("thumbnails/images/cropped/") + name + string(".png");
+      thumbnail_path.toStdString() +
+      "/images/cropped/" +
+      name +
+      string(".png");
   qInfo("loading: [%s]", filename.c_str());
   QImageReader image_reader(QString::fromStdString(filename));
   image_reader.setAutoTransform(true);  // not sure what this does

--- a/gui/level_dialog.cpp
+++ b/gui/level_dialog.cpp
@@ -91,7 +91,6 @@ LevelDialog::~LevelDialog()
 
 void LevelDialog::drawing_filename_button_clicked()
 {
-  printf("filename button clicked\n");
   QFileDialog file_dialog(this, "Find Drawing");
   file_dialog.setFileMode(QFileDialog::ExistingFile);
   file_dialog.setNameFilter("*.png");

--- a/gui/main.cpp
+++ b/gui/main.cpp
@@ -18,12 +18,15 @@
 #include "editor.h"
 #include <QtWidgets>
 #include <string>
+#include <QSettings>
 
 int main(int argc, char *argv[])
 {
   QApplication app(argc, argv);
-
-  QGuiApplication::setApplicationDisplayName("Traffic Editor");
+  app.setOrganizationName("open-robotics");
+  app.setOrganizationDomain("openrobotics.org");
+  app.setApplicationName("traffic-editor");
+  app.setApplicationDisplayName("Traffic Editor");
 
   QCommandLineParser parser;
   parser.addHelpOption();
@@ -32,10 +35,10 @@ int main(int argc, char *argv[])
 
   Editor editor;
   QString filename;
-  if (!parser.positionalArguments().isEmpty()) {
-    filename = parser.positionalArguments().front();
-    editor.load_project(filename);
-  }
+  if (!parser.positionalArguments().isEmpty())
+    editor.load_project(parser.positionalArguments().front());
+  else
+    editor.load_previous_project();
 
   editor.show();
 

--- a/gui/preferences_dialog.cpp
+++ b/gui/preferences_dialog.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2019 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "preferences_dialog.h"
+#include <QtWidgets>
+
+
+PreferencesDialog::PreferencesDialog(QWidget *parent)
+: QDialog(parent)
+{
+  QSettings settings;
+
+  ok_button = new QPushButton("OK", this);  // first button = [enter] button
+  cancel_button = new QPushButton("Cancel", this);
+
+  QHBoxLayout *thumbnail_path_layout = new QHBoxLayout;
+  thumbnail_path_line_edit = new QLineEdit(
+      settings.value("editor/thumbnail_path").toString(), this);
+  thumbnail_path_button = new QPushButton("Find...", this);
+  thumbnail_path_layout->addWidget(new QLabel("thumbnail path:"));
+  thumbnail_path_layout->addWidget(thumbnail_path_line_edit);
+  thumbnail_path_layout->addWidget(thumbnail_path_button);
+  connect(
+      thumbnail_path_button, &QAbstractButton::clicked,
+      this, &PreferencesDialog::thumbnail_path_button_clicked);
+
+  QHBoxLayout *bottom_buttons_layout = new QHBoxLayout;
+  bottom_buttons_layout->addWidget(cancel_button);
+  bottom_buttons_layout->addWidget(ok_button);
+  connect(
+      ok_button, &QAbstractButton::clicked,
+      this, &PreferencesDialog::ok_button_clicked);
+  connect(
+      cancel_button, &QAbstractButton::clicked,
+      this, &QDialog::reject);
+
+  QVBoxLayout *vbox_layout = new QVBoxLayout;
+  vbox_layout->addLayout(thumbnail_path_layout);
+  // todo: some sort of separator (?)
+  vbox_layout->addLayout(bottom_buttons_layout);
+
+  setLayout(vbox_layout);
+}
+
+PreferencesDialog::~PreferencesDialog()
+{
+}
+
+void PreferencesDialog::thumbnail_path_button_clicked()
+{
+  QFileDialog file_dialog(this, "Find Thumbnail Path");
+  file_dialog.setFileMode(QFileDialog::ExistingFile);
+  file_dialog.setNameFilter("model_list.yaml");
+  if (file_dialog.exec() != QDialog::Accepted)
+    return;  // user clicked 'cancel'
+
+  const QString model_list_path = file_dialog.selectedFiles().first();
+  if (!QFileInfo(model_list_path).exists())
+  {
+    QMessageBox::critical(
+        this,
+        "model_list.yaml file does not exist",
+        "File does not exist.");
+    return;
+  }
+  thumbnail_path_line_edit->setText(
+      QFileInfo(model_list_path).dir().absolutePath());
+}
+
+void PreferencesDialog::ok_button_clicked()
+{
+  if (!thumbnail_path_line_edit->text().isEmpty()) {
+    // make sure the path exists
+    if (!QFileInfo(thumbnail_path_line_edit->text()).exists()) {
+      QMessageBox::critical(
+          this,
+          "Thumbnail path must exist",
+          "Thumbnail path must exist");
+      return;
+    }
+  }
+
+  QSettings settings;
+  settings.setValue("editor/thumbnail_path", thumbnail_path_line_edit->text());
+
+  accept();
+}

--- a/gui/preferences_dialog.h
+++ b/gui/preferences_dialog.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2019 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef PREFERENCES_DIALOG_H
+#define PREFERENCES_DIALOG_H
+
+#include <QDialog>
+class QLineEdit;
+
+
+class PreferencesDialog : public QDialog
+{
+public:
+  PreferencesDialog(QWidget *parent);
+  ~PreferencesDialog();
+ 
+private:
+  QLineEdit *thumbnail_path_line_edit;
+  QPushButton *thumbnail_path_button;
+  QPushButton *ok_button, *cancel_button;
+
+private slots:
+  void thumbnail_path_button_clicked();
+  void ok_button_clicked();
+};
+
+#endif


### PR DESCRIPTION
Change working directory of editor to the directory of the YAML file being loaded, so that the relative paths of the drawing files can be used. Otherwise, absolute paths or other brittle paths are used, making the project files not load nicely across different machines and source-tree paths.

As a consequence, the path to the thumbnails and the thumbnail `model_list.yaml` file had to be saved somewhere, rather than just "hoping" that the thumbnail directory `thumbnails` happened to be already symlinked into the execution directory of `traffic-editor`. So this PR also adds in a `QSettings` instantiation to hold the absolute path of the `thumbnails` directory. For now, it is assumed to be the a sibling directory of the build directory, but the `thumbnails` path can now be edited (persistently) using the `Edit->Preferences...` dialog. Changes in there will be saved using `QSettings` into a settings file in `~/.config/` according to the rules of `QSettings`.