### PR TITLE
add is_charger vertex parameter

### DIFF
--- a/gui/vertex.cpp
+++ b/gui/vertex.cpp
@@ -26,6 +26,7 @@ using std::pair;
 const vector<pair<string, Param::Type> > Vertex::allowed_params
 {
   { "is_parking_spot", Param::Type::BOOL },
+  { "is_charger", Param::Type::BOOL},
   { "workcell_name", Param::Type::STRING }
 };
 


### PR DESCRIPTION
no more guessing if it's a charger based on substrings with the vertex name!